### PR TITLE
Dialogue graph exit node is now saved

### DIFF
--- a/Assets/Data/Dialogue Graphs/SithTestDialogue.asset
+++ b/Assets/Data/Dialogue Graphs/SithTestDialogue.asset
@@ -53,3 +53,8 @@ MonoBehaviour:
   - name: Transition
     from: 4
     to: 2
+  exitNode:
+    name: Exit
+    body: 
+    position: {x: -218, y: -175}
+    questNotes: []

--- a/Assets/Scripts/Editor/DialogueGraphWindow.cs
+++ b/Assets/Scripts/Editor/DialogueGraphWindow.cs
@@ -69,6 +69,7 @@ namespace Dialogue
                     else if (hoverNode == null)
                     {
                         selectedGraph.selectedNode = -1;
+                        EditorUtility.SetDirty(selectedGraph);
                     }
                 }
                 else if (e.button == 1)

--- a/Assets/Scripts/Tools/Dialogue Graph/DialogueGraph.cs
+++ b/Assets/Scripts/Tools/Dialogue Graph/DialogueGraph.cs
@@ -17,7 +17,7 @@ namespace Dialogue
 
         public List<DialogueGraphNode> nodes = new List<DialogueGraphNode>();
         public List<DialogueGraphTransition> transitions = new List<DialogueGraphTransition>();
-        [System.NonSerialized] public readonly DialogueGraphNode exitNode = new DialogueGraphNode("Exit", new Vector2(200, 0));
+        public DialogueGraphNode exitNode = new DialogueGraphNode("Exit", new Vector2(200, 0));
         [System.NonSerialized] public int selectedNode;
 
         public void Draw(Vector2 offset)
@@ -33,10 +33,11 @@ namespace Dialogue
                 if (nodes[i].ProcessEvents(e))
                 {
                     selectedNode = i;
+                    EditorUtility.SetDirty(this);
                 }
             }
 
-            exitNode.ProcessEvents(e);
+            if(exitNode.ProcessEvents(e)) EditorUtility.SetDirty(this);
         }
 
         public void CreateNode(string name, Vector2 position)


### PR DESCRIPTION
Removed `[NonSerialized]` attribute and `readonly` modifier to serialize the exit node and save its position.

Fixes #46 